### PR TITLE
Remove cyclic reference from customwidget

### DIFF
--- a/customwidget/application.cpp
+++ b/customwidget/application.cpp
@@ -11,34 +11,20 @@ Application::Application(QWidget *parent)
 void Application::initUI() {
 
   const int MAX_VALUE = 750;
-  cur_width = 0;
 
   slider = new QSlider(Qt::Horizontal , this);
   slider->setMaximum(MAX_VALUE);
   slider->setGeometry(50, 50, 170, 30);
 
-  connect(slider, &QSlider::valueChanged, this, &Application::valueChanged);
+  widget = new Widget(this);
+  connect(slider, &QSlider::valueChanged, widget, &Widget::setValue);
 
   auto *vbox = new QVBoxLayout(this);
   auto *hbox = new QHBoxLayout();
 
   vbox->addStretch(1);
-
-  widget = new Widget(this);
   hbox->addWidget(widget, 0);
-
   vbox->addLayout(hbox);
 
   setLayout(vbox);
-}
-
-void Application::valueChanged(int val) {
-
-  cur_width = val;
-  widget->repaint();
-}
-
-int Application::getCurrentWidth() {
-
-  return cur_width;
 }

--- a/customwidget/application.h
+++ b/customwidget/application.h
@@ -11,15 +11,10 @@ class Application : public QFrame {
 
   public:
     Application(QWidget *parent = nullptr);
-    int getCurrentWidth();
-
-  public slots:
-    void valueChanged(int);
 
   private:
     QSlider *slider;
     Widget *widget;
-    int cur_width;
 
     void initUI();
 };

--- a/customwidget/widget.cpp
+++ b/customwidget/widget.cpp
@@ -1,13 +1,18 @@
 #include <QtGui>
 #include "widget.h"
-#include "application.h"
 
 const int PANEL_HEIGHT = 30;
 
-Widget::Widget(Application *parent)
-    : QFrame(parent), app{parent} {
+Widget::Widget(QWidget *parent)
+    : QFrame(parent), cur_width(0) {
 
   setMinimumHeight(PANEL_HEIGHT);
+}
+
+void Widget::setValue(int value)
+{
+  cur_width = value;
+  repaint();
 }
 
 void Widget::paintEvent(QPaintEvent *e) {
@@ -29,8 +34,6 @@ void Widget::drawWidget(QPainter &qp) {
   QColor yellowColor(255, 255, 184);
 
   int width = size().width();
-
-  int cur_width = app->getCurrentWidth();
 
   int step = (int) qRound((double)width / DIVISIONS);
   int till = (int) ((width / MAX_CAPACITY) * cur_width);

--- a/customwidget/widget.h
+++ b/customwidget/widget.h
@@ -2,19 +2,22 @@
 
 #include <QFrame>
 
-class Application;
-
 class Widget : public QFrame {
 
+  Q_OBJECT;
+
   public:
-    Widget(Application *parent = nullptr);
+    Widget(QWidget *parent = nullptr);
+
+  public slots:
+    void setValue(int);
 
   protected:
     void paintEvent(QPaintEvent *e);
     void drawWidget(QPainter &qp);
 
   private:
-    Application *app;
+    int cur_width;
 
     static constexpr int DISTANCE = 19;
     static constexpr int LINE_WIDTH = 5;


### PR DESCRIPTION
Hey!

I've been working through your Qt5 tutorials and I noticed a cyclic reference in this example and thought I'd refactor it.
After the refactor the `Widget` now owns the information about its current-width - this is coupled to the slider via signal-slot. In other words, the application now passes information to the widget on how it should draw itself, rather than the widget querying the application about it.
I hope this makes sense.

Best regards